### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # fnafjolt [![GitHub release](https://img.shields.io/github/release/niksudan/fnafjolt.svg)](https://github.com/niksudan/fnafjolt/releases)
 
 A [Twitter bot account](http://twitter.com/fnafjolt) that tweets the latest FNAF fangames from Game Jolt. Be prepared for ridiculousness.
+
+[![Run on Repl.it](https://repl.it/badge/github/niksudan/fnafjolt)](https://repl.it/github/niksudan/fnafjolt)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).